### PR TITLE
Updating UnionFindLib to use uint64_t as its VertexID Type

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -8,13 +8,12 @@ ANCHOR= -DANCHOR_ALGO
 #ANCHOR= 
 PROFILE= -DPROFILING
 CHARMC = $(CHARM_DIR)/bin/charmc $(PROFILE) #$(ANCHOR)
-OPTS = -std=c++11 -O0 -g #was -03
+OPTS = -std=c++11 -O3 -g
 LD_OPTS =
-# CK_TEMPLATES = -DCK_TEMPLATES_ONLY
 
 #options for building union-find library and prefix library
 PREFIX_LIBS = -L${PREFIX_LIB_DIR} -lprefix
-PREFIX_INC = -I${PREFIX_LIB_DIR} # ${CK_TEMPLATES}
+PREFIX_INC = -I${PREFIX_LIB_DIR}
 
 UNION_FIND_LIBS = -L${UNION_FIND_DIR} -lunionFind ${PREFIX_LIBS}
 UNION_FIND_INC = -I${UNION_FIND_DIR} ${PREFIX_INC} 

--- a/Makefile.common
+++ b/Makefile.common
@@ -1,19 +1,20 @@
 #set the following variables to absolute paths
-CHARM_DIR = /Users/raghu/work/charm/charm
-UNION_FIND_DIR = /Users/raghu/work/charm/unionFind/unionFind
+CHARM_DIR = /Users/johnnychen/Documents/Projects/research/charm
+UNION_FIND_DIR = /Users/johnnychen/Documents/Projects/research/unionfind
 PREFIX_LIB_DIR = $(UNION_FIND_DIR)/prefixLib
 
 #charmc options
 ANCHOR= -DANCHOR_ALGO
 #ANCHOR= 
 PROFILE= -DPROFILING
-CHARMC = $(CHARM_DIR)/bin/charmc $(ANCHOR) $(PROFILE)
-OPTS = -std=c++11 -O3 -g
+CHARMC = $(CHARM_DIR)/bin/charmc $(PROFILE) #$(ANCHOR)
+OPTS = -std=c++11 -O0 -g #was -03
 LD_OPTS =
+# CK_TEMPLATES = -DCK_TEMPLATES_ONLY
 
 #options for building union-find library and prefix library
 PREFIX_LIBS = -L${PREFIX_LIB_DIR} -lprefix
-PREFIX_INC = -I${PREFIX_LIB_DIR}
+PREFIX_INC = -I${PREFIX_LIB_DIR} # ${CK_TEMPLATES}
 
 UNION_FIND_LIBS = -L${UNION_FIND_DIR} -lunionFind ${PREFIX_LIBS}
-UNION_FIND_INC = -I${UNION_FIND_DIR} ${PREFIX_INC}
+UNION_FIND_INC = -I${UNION_FIND_DIR} ${PREFIX_INC} 

--- a/examples/simple_graph/graph.C
+++ b/examples/simple_graph/graph.C
@@ -147,7 +147,7 @@ class TreePiece : public CBase_TreePiece {
         libPtr = libProxy[thisIndex].ckLocal();
         libPtr->initialize_vertices(libVertices, numMyVertices);
         libPtr->registerGetLocationFromID(getLocationFromID);
-        contribute(CkCallback(CkReductionTarget(Main, startWork), mainProxy));
+        contribute(CkCallback(CkReductionTarget(Main, Main::startWork), mainProxy));
     }
 
     void doWork() {
@@ -172,7 +172,7 @@ class TreePiece : public CBase_TreePiece {
                 CkAbort("Something wrong in inverted-tree construction!\n");
             }
         }
-        contribute(CkCallback(CkReductionTarget(Main, donePrinting), mainProxy));
+        contribute(CkCallback(CkReductionTarget(Main, Main::donePrinting), mainProxy));
     }
 
     void getConnectedComponents() {

--- a/examples/simple_graph/graph.C
+++ b/examples/simple_graph/graph.C
@@ -130,7 +130,7 @@ class TreePiece : public CBase_TreePiece {
     // function that must be always defined by application
     // return type -> std::pair<int, int>
     // this specific logic assumes equal distribution of vertices across all tps
-    static std::pair<int, int> getLocationFromID(long int vid);
+    static std::pair<int, int> getLocationFromID(uint64_t vid);
 
     void initializeLibVertices() {
         // provide vertices data to library
@@ -147,7 +147,7 @@ class TreePiece : public CBase_TreePiece {
         libPtr = libProxy[thisIndex].ckLocal();
         libPtr->initialize_vertices(libVertices, numMyVertices);
         libPtr->registerGetLocationFromID(getLocationFromID);
-        contribute(CkCallback(CkReductionTarget(Main, Main::startWork), mainProxy));
+        contribute(CkCallback(CkReductionTarget(Main, startWork), mainProxy));
     }
 
     void doWork() {
@@ -172,7 +172,7 @@ class TreePiece : public CBase_TreePiece {
                 CkAbort("Something wrong in inverted-tree construction!\n");
             }
         }
-        contribute(CkCallback(CkReductionTarget(Main, Main::donePrinting), mainProxy));
+        contribute(CkCallback(CkReductionTarget(Main, donePrinting), mainProxy));
     }
 
     void getConnectedComponents() {
@@ -203,7 +203,7 @@ TreePiece::getLocationFromID(long int vid) {
 */
 
 std::pair<int, int>
-TreePiece::getLocationFromID(long int vid) {
+TreePiece::getLocationFromID(uint64_t vid) {
     int chareIdx = (vid-1) % NUM_TREEPIECES;
     int arrIdx = (vid-1) / NUM_TREEPIECES;
     return std::make_pair(chareIdx, arrIdx);

--- a/prefixLib/Makefile
+++ b/prefixLib/Makefile
@@ -3,7 +3,7 @@ CHARMC=/Users/raghu/work/charm/charm/bin/charmc $(OPTS)
 all: libprefix.a
 
 libprefix.a: prefixBalance.o
-	$(CHARMC) prefixBalance.o -o libprefix.a -language charm++
+	$(CHARMC) prefixBalance.o -o libprefix.a -language charm++ # -DCK_TEMPLATES_ONLY
 
 prefixBalance.o : prefixBalance.C prefixBalance.def.h prefixBalance.decl.h
 	$(CHARMC) -c prefixBalance.C

--- a/types.h
+++ b/types.h
@@ -26,7 +26,7 @@ struct anchorData {
 
 struct shortCircuitData {
     uint64_t arrIdx;
-    uint64_t grandparentID;
+    int64_t grandparentID;
 
     void pup(PUP::er &p) {
         p|arrIdx;

--- a/types.h
+++ b/types.h
@@ -12,6 +12,16 @@ struct findBossData {
     }
 };
 
+struct needBossData {
+    uint64_t arrIdx;
+    uint64_t senderID;
+
+    void pup(PUP::er &p) {
+        p|arrIdx;
+        p|senderID;
+    }
+};
+
 #ifdef ANCHOR_ALGO
 struct anchorData {
     uint64_t arrIdx;

--- a/unionFindLib.C
+++ b/unionFindLib.C
@@ -100,7 +100,6 @@ initialize_vertices(unionFindVertex *appVertices, int numVertices) {
 #ifndef ANCHOR_ALGO
 void UnionFindLib::
 union_request(uint64_t vid1, uint64_t vid2) {
-    CkPrintf("[unionfind] union_request on %llu, %llu\n", v, w);
     assert(vid1!=vid2);
     if (vid2 < vid1) {
         // found a back edge, flip and reprocess
@@ -127,7 +126,6 @@ union_request(uint64_t vid1, uint64_t vid2) {
 #else
 void UnionFindLib::
 union_request(uint64_t v, uint64_t w) {
-    CkPrintf("[unionfind] union_request on %llu, %llu\n", v, w);
     std::pair<int, int> w_loc = getLocationFromID(w);
     // message w to anchor to v
     anchorData d;

--- a/unionFindLib.C
+++ b/unionFindLib.C
@@ -564,9 +564,9 @@ set_component(int arrIdx, long int compNum) {
     myVertices[arrIdx].componentNumber = compNum;
 
     // since component number is set, respond to your requestors
-    std::vector<uint64_t>::iterator req_iter = myVertices[arrIdx].need_boss_requests.begin();
-    while (req_iter != myVertices[arrIdx].need_boss_requests.end()) {
-        uint64_t requestorID = *req_iter;
+    std::vector<uint64_t> need_boss_queue = myVertices[arrIdx].need_boss_requests;
+    while (!need_boss_queue.empty()) {
+        uint64_t requestorID = (need_boss_queue).back();
         std::pair<int, int> requestor_loc = getLocationFromID(requestorID);
         if (requestor_loc.first == thisIndex) {
             set_component(requestor_loc.second, compNum);
@@ -574,7 +574,7 @@ set_component(int arrIdx, long int compNum) {
             this->thisProxy[requestor_loc.first].set_component(requestor_loc.second, compNum);
         }
         // done with current requestor, delete from request queue
-        req_iter = myVertices[arrIdx].need_boss_requests.erase(req_iter);
+        need_boss_queue.pop_back();
     }
 }
 

--- a/unionFindLib.ci
+++ b/unionFindLib.ci
@@ -18,13 +18,13 @@ module unionFindLib {
         entry void find_boss1(int arrIdx, uint64_t partnerID, uint64_t initID);
         entry void find_boss2(int arrIdx, uint64_t boss1ID, uint64_t initID);
 #else
-        entry void anchor(int w_arrIdx, long v, long path_base_arrIdx);
+        entry void anchor(int w_arrIdx, uint64_t v, long path_base_arrIdx);
 #endif
         // function for grandparent short-circuiting
         entry [aggregate] void short_circuit_parent(shortCircuitData scd);
 
         // function for path compression support
-        entry void compress_path(int arrIdx, int64_t compressedParent);
+        entry void compress_path(int arrIdx, uint64_t compressedParent);
 
         // functions to perform distributed connected components
         entry void find_components(CkCallback cb);

--- a/unionFindLib.ci
+++ b/unionFindLib.ci
@@ -15,8 +15,8 @@ module unionFindLib {
         entry void register_phase_one_cb(CkCallback cb);
         // functions to build inverted trees
 #ifndef ANCHOR_ALGO
-        entry void find_boss1(int arrIdx, long partnerID, long initID);
-        entry void find_boss2(int arrIdx, long boss1ID, long initID);
+        entry void find_boss1(int arrIdx, uint64_t partnerID, uint64_t initID);
+        entry void find_boss2(int arrIdx, uint64_t boss1ID, uint64_t initID);
 #else
         entry void anchor(int w_arrIdx, long v, long path_base_arrIdx);
 #endif
@@ -24,12 +24,12 @@ module unionFindLib {
         entry [aggregate] void short_circuit_parent(shortCircuitData scd);
 
         // function for path compression support
-        entry void compress_path(int arrIdx, long compressedParent);
+        entry void compress_path(int arrIdx, int64_t compressedParent);
 
         // functions to perform distributed connected components
         entry void find_components(CkCallback cb);
         entry [reductiontarget] void boss_count_prefix_done(int totalCount);
-        entry void need_boss(int arrIdx, int fromID);
+        entry void need_boss(int arrIdx, uint64_t fromID);
         entry void set_component(int arrIdx, int compNum);
 
         // functions to prune out small components
@@ -40,7 +40,7 @@ module unionFindLib {
 
         // TRAM functions
         entry [aggregate] void insertDataFindBoss(const findBossData & data);
-        entry [aggregate] void insertDataNeedBoss(const uint64_t & data);
+        entry [aggregate] void insertDataNeedBoss(const needBossData & data);
 #ifdef ANCHOR_ALGO
         entry [aggregate] void insertDataAnchor(const anchorData & data);
 #endif

--- a/unionFindLib.h
+++ b/unionFindLib.h
@@ -58,13 +58,13 @@ class UnionFindLib : public CBase_UnionFindLib {
     void find_boss1(int arrIdx, uint64_t partnerID, uint64_t senderID);
     void find_boss2(int arrIdx, uint64_t boss1ID, uint64_t senderID);
 #else
-    void union_request(long int v, long int w);
-    void anchor(int w_arrIdx, long int v, long int path_base_arrIdx);
+    void union_request(uint64_t v, uint64_t w);
+    void anchor(int w_arrIdx, uint64_t v, long int path_base_arrIdx);
 #endif
     void local_path_compression(unionFindVertex *src, uint64_t compressedParent);
     bool check_same_chares(uint64_t v1, uint64_t v2);
     void short_circuit_parent(shortCircuitData scd);
-    void compress_path(int arrIdx, int64_t compressedParent);
+    void compress_path(int arrIdx, uint64_t compressedParent);
     unionFindVertex *return_vertices();
 
     // functions and data structures for finding connected components

--- a/unionFindLib.h
+++ b/unionFindLib.h
@@ -8,7 +8,7 @@ struct unionFindVertex {
     uint64_t vertexID;
     int64_t parent;
     long int componentNumber = -1;
-    std::vector<long int> need_boss_requests; //request queue for processing need_boss requests
+    std::vector<uint64_t> need_boss_requests; //request queue for processing need_boss requests
     long int findOrAnchorCount = 0;
 
     void pup(PUP::er &p) {
@@ -73,12 +73,12 @@ class UnionFindLib : public CBase_UnionFindLib {
     void find_components(CkCallback cb);
     void boss_count_prefix_done(int totalCount);
     void start_component_labeling();
-    void insertDataNeedBoss(const uint64_t & data);
+    void insertDataNeedBoss(const needBossData & data);
     void insertDataFindBoss(const findBossData & data);
 #ifdef ANCHOR_ALGO
     void insertDataAnchor(const anchorData & data);
 #endif
-    void need_boss(int arrIdx, long int fromID);
+    void need_boss(int arrIdx, uint64_t fromID);
     void set_component(int arrIdx, long int compNum);
     void prune_components(int threshold, CkCallback appReturnCb);
     void perform_pruning();

--- a/unionFindLib.h
+++ b/unionFindLib.h
@@ -5,8 +5,8 @@
 #include <NDMeshStreamer.h>
 
 struct unionFindVertex {
-    long int vertexID;
-    long int parent;
+    uint64_t vertexID;
+    int64_t parent;
     long int componentNumber = -1;
     std::vector<long int> need_boss_requests; //request queue for processing need_boss requests
     long int findOrAnchorCount = 0;
@@ -41,7 +41,7 @@ class UnionFindLib : public CBase_UnionFindLib {
     int numMyVertices;
     int pathCompressionThreshold = 5;
     int componentPruneThreshold;
-    std::pair<int, int> (*getLocationFromID)(long int vid);
+    std::pair<int, int> (*getLocationFromID)(uint64_t vid);
     int myLocalNumBosses;
     int totalNumBosses;
     CkCallback postComponentLabelingCb;
@@ -50,22 +50,22 @@ class UnionFindLib : public CBase_UnionFindLib {
     UnionFindLib() {}
     UnionFindLib(CkMigrateMessage *m) { }
     static CProxy_UnionFindLib unionFindInit(CkArrayID clientArray, int n);
+    void registerGetLocationFromID(std::pair<int, int> (*gloc)(uint64_t vid));
     void register_phase_one_cb(CkCallback cb);
     void initialize_vertices(unionFindVertex *appVertices, int numVertices);
 #ifndef ANCHOR_ALGO
-    void union_request(long int vid1, long int vid2);
-    void find_boss1(int arrIdx, long int partnerID, long int senderID);
-    void find_boss2(int arrIdx, long int boss1ID, long int senderID);
+    void union_request(uint64_t vid1, uint64_t vid2);
+    void find_boss1(int arrIdx, uint64_t partnerID, uint64_t senderID);
+    void find_boss2(int arrIdx, uint64_t boss1ID, uint64_t senderID);
 #else
     void union_request(long int v, long int w);
     void anchor(int w_arrIdx, long int v, long int path_base_arrIdx);
 #endif
-    void local_path_compression(unionFindVertex *src, long int compressedParent);
-    bool check_same_chares(long int v1, long int v2);
+    void local_path_compression(unionFindVertex *src, uint64_t compressedParent);
+    bool check_same_chares(uint64_t v1, uint64_t v2);
     void short_circuit_parent(shortCircuitData scd);
-    void compress_path(int arrIdx, long int compressedParent);
-    unionFindVertex* return_vertices();
-    void registerGetLocationFromID(std::pair<int, int> (*gloc)(long int v));
+    void compress_path(int arrIdx, int64_t compressedParent);
+    unionFindVertex *return_vertices();
 
     // functions and data structures for finding connected components
 


### PR DESCRIPTION
### UnionFindLib

types.h

- added `needBossData` struct as data container for `unionFindLib::insertDataNeedBoss` parameters
- redefined `struct shortCircuitData` to use

unionFindLib.h

- updated functions to use `uint64_t` for vertexIDs

unionFindLib.C

- updated functions to use `uint64_t` for vertexIDs

[unionFindLib.ci](http://unionfindlib.ci/)

- updated functions to use `uint64_t` for vertexIDs

MISC commenting for documentation on core union find lib API functions.

Note: I have temporarily commented out the ANCHOR_ALGO since it has not been tested after we updated the interface to use `uint64_t` for vertexIDs, though it is an improvement over the old algorithm currently compiled by default.